### PR TITLE
Update packages.json

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3,27 +3,18 @@
 	"packages": [
 		{
 			"name": "Japanize",
-			"author": "kik0220",
-			"description": "Japanese menu for Sublime Text 2/3",
 			"homepage": "https://github.com/kik0220/sublimetext_japanize",
-			"issues":  "https://github.com/kik0220/sublimetext_japanize/issues",
 			"labels": ["theme"],
 			"releases": [
 				{
 					"details": "https://github.com/kik0220/sublimetext_japanize/tree/2999",
 					"platforms": ["*"],
-					"sublime_text": "<3000",
-					"version": "2013.08.30.06.00.00",
-					"date":    "2013-08-30 06:00:00",
-					"url": "https://codeload.github.com/kik0220/sublimetext_japanize/zip/2999"
+					"sublime_text": "<3000"
 				},
 				{
-					"details": "https://github.com/kik0220/sublimetext_japanize",
+					"details": "https://github.com/kik0220/sublimetext_japanize/tree/master",
 					"platforms": ["*"],
-					"sublime_text": ">2999",
-					"version": "2013.08.30.06.00.00",
-					"date":    "2013-08-30 06:00:00",
-					"url": "https://codeload.github.com/kik0220/sublimetext_japanize/zip/master"
+					"sublime_text": ">2999"
 				}
 			]
 		}


### PR DESCRIPTION
Removed redundant keys (some are ignored, some are the same as the default values)

```
======================================================================
FAIL: test_release('Japanize (https://raw.github.com/kik0220/sublimetext_japanize/master/packages.json)', {'details': 'https://github.com/kik0220/sublimetext_japanize', 'date': '2013-08-30 06:00:00', 'platforms': ['*'], 'url': 'https://codeload.github.com/kik0220/sublimetext_japanize/zip/master', 'version': '2013.08.30.06.00.00', 'sublime_text': '>2999'}, False) (__main__.ChannelTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests\test.py", line 74, in wrapper
    return method(self, *params)
  File "tests\test.py", line 220, in _test_release
    'specified' % req)
AssertionError: 'url' unexpectedly found in {'details': 'https://github.com/kik0220/sublimetext_japanize', 'date': '2013-08-30 06:00:00', 'platforms': ['*'], 'url': 'https://codeload.github.com/kik0220/sublimetext_japanize/zip/master', 'version': '2013.08.30.06.00.00', 'sublime_text': '>2999'} : The key "url" is redundant when "details" is specified

======================================================================
FAIL: test_release('Japanize (https://raw.github.com/kik0220/sublimetext_japanize/master/packages.json)', {'details': 'https://github.com/kik0220/sublimetext_japanize/tree/2999', 'date': '2013-08-30 06:00:00', 'platforms': ['*'], 'url': 'https://codeload.github.com/kik0220/sublimetext_japanize/zip/2999', 'version': '2013.08.30.06.00.00', 'sublime_text': '<3000'}, False) (__main__.ChannelTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests\test.py", line 74, in wrapper
    return method(self, *params)
  File "tests\test.py", line 220, in _test_release
    'specified' % req)
AssertionError: 'url' unexpectedly found in {'details': 'https://github.com/kik0220/sublimetext_japanize/tree/2999', 'date': '2013-08-30 06:00:00', 'platforms': ['*'], 'url': 'https://codeload.github.com/kik0220/sublimetext_japanize/zip/2999', 'version': '2013.08.30.06.00.00', 'sublime_text': '<3000'} : The key "url" is redundant when "details" is specified
```
