### PR TITLE
Provide details url and remove redundant keys

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3,20 +3,14 @@
 	"packages": [
 		{
 			"name": "Japanize",
-			"author": "kik0220",
-			"description": "Japanese menu for Sublime Text 2/3",
-			"homepage": "https://github.com/kik0220/sublimetext_japanize",
-			"issues":  "https://github.com/kik0220/sublimetext_japanize/issues",
-			"labels": ["theme"],
+			"details": "https://github.com/kik0220/sublimetext_japanize",
 			"releases": [
 				{
 					"details": "https://github.com/kik0220/sublimetext_japanize/tree/2999",
-					"platforms": ["*"],
 					"sublime_text": "<3000"
 				},
 				{
 					"details": "https://github.com/kik0220/sublimetext_japanize/tree/master",
-					"platforms": ["*"],
 					"sublime_text": ">=3000"
 				}
 			]


### PR DESCRIPTION
By providing the details url you can get rid of pretty much all others because they are defaulted to the ones you supplied. Furthermore, this will display a readme on https://sublime.wbond.net/packages/Japanize.

Also, the `theme` tag is inappropriate.
